### PR TITLE
Add minimal prompt generation option

### DIFF
--- a/app/src/main/java/com/samsung/genuiapp/MainActivity.kt
+++ b/app/src/main/java/com/samsung/genuiapp/MainActivity.kt
@@ -53,10 +53,12 @@ class MainActivity : AppCompatActivity() {
         binding.promptInput.setText(getString(R.string.sample_prompt))
 
         binding.generateButton.isEnabled = false
+        binding.generateMinimalButton.isEnabled = false
 
         binding.modelPathLayout.setEndIconOnClickListener { openModelPicker() }
         binding.loadModelButton.setOnClickListener { loadModel() }
-        binding.generateButton.setOnClickListener { generateUi() }
+        binding.generateButton.setOnClickListener { generateUi(useMinimalPrompt = false) }
+        binding.generateMinimalButton.setOnClickListener { generateUi(useMinimalPrompt = true) }
     }
 
     private fun restoreLastModelPath() {
@@ -87,6 +89,7 @@ class MainActivity : AppCompatActivity() {
         updateStatus("Loading model...")
         binding.loadModelButton.isEnabled = false
         binding.generateButton.isEnabled = false
+        binding.generateMinimalButton.isEnabled = false
 
         val threads = maxOf(1, Runtime.getRuntime().availableProcessors() - 1)
         lifecycleScope.launch {
@@ -108,6 +111,7 @@ class MainActivity : AppCompatActivity() {
             if (success) {
                 isModelReady = true
                 binding.generateButton.isEnabled = true
+                binding.generateMinimalButton.isEnabled = true
                 getPreferences(MODE_PRIVATE).edit()
                     .putString(KEY_MODEL_PATH, requestedPath)
                     .putString(KEY_MODEL_LOCAL_PATH, preparedPath)
@@ -120,7 +124,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun generateUi() {
+    private fun generateUi(useMinimalPrompt: Boolean) {
         if (!isModelReady) {
             updateStatus("Load the model first.")
             return
@@ -134,6 +138,7 @@ class MainActivity : AppCompatActivity() {
 
         val previewIntent = Intent(this, PreviewActivity::class.java).apply {
             putExtra(PreviewActivity.EXTRA_PROMPT_TEXT, agentText)
+            putExtra(PreviewActivity.EXTRA_USE_MINIMAL_PROMPT, useMinimalPrompt)
         }
         startActivity(previewIntent)
     }
@@ -146,6 +151,7 @@ class MainActivity : AppCompatActivity() {
         binding.progressBar.isVisible = false
         binding.loadModelButton.isEnabled = true
         binding.generateButton.isEnabled = isModelReady
+        binding.generateMinimalButton.isEnabled = isModelReady
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/samsung/genuiapp/PreviewActivity.kt
+++ b/app/src/main/java/com/samsung/genuiapp/PreviewActivity.kt
@@ -41,6 +41,7 @@ class PreviewActivity : AppCompatActivity() {
 
     private fun startGeneration() {
         val promptText = intent.getStringExtra(EXTRA_PROMPT_TEXT).orEmpty()
+        val useMinimalPrompt = intent.getBooleanExtra(EXTRA_USE_MINIMAL_PROMPT, false)
         if (promptText.isBlank()) {
             showError(getString(R.string.preview_error, getString(R.string.prompt_hint)))
             return
@@ -50,7 +51,7 @@ class PreviewActivity : AppCompatActivity() {
         binding.previewStatus.text = getString(R.string.preview_generating)
 
         lifecycleScope.launch {
-            val prompt = UiGenerationUtils.buildPrompt(promptText)
+            val prompt = UiGenerationUtils.buildPrompt(promptText, useMinimalPrompt)
             val output = withContext(Dispatchers.IO) {
                 runCatching { QwenCoderBridge.generate(prompt, UiGenerationUtils.MAX_TOKENS) }
                     .getOrElse { throwable -> "[error] ${throwable.localizedMessage}" }
@@ -76,5 +77,6 @@ class PreviewActivity : AppCompatActivity() {
 
     companion object {
         const val EXTRA_PROMPT_TEXT = "extra_prompt_text"
+        const val EXTRA_USE_MINIMAL_PROMPT = "extra_use_minimal_prompt"
     }
 }

--- a/app/src/main/java/com/samsung/genuiapp/UiGenerationUtils.kt
+++ b/app/src/main/java/com/samsung/genuiapp/UiGenerationUtils.kt
@@ -27,9 +27,17 @@ object UiGenerationUtils {
         - Put data-action and, when helpful, data-payload JSON on all interactive elements.
     """.trimIndent()
 
-    fun buildPrompt(agentText: String): String {
+    private val MINIMAL_PROMPT_TEMPLATE = """
+        Produce a mobile-friendly HTML UI inside a single ```html code block.
+
+        # agent_text
+        {{agent_text}}
+    """.trimIndent()
+
+    fun buildPrompt(agentText: String, useMinimalPrompt: Boolean = false): String {
         val sanitizedAgentText = agentText.ifBlank { "No agent output provided." }
-        return USER_PROMPT_TEMPLATE.replace(USER_PROMPT_PLACEHOLDER, sanitizedAgentText)
+        val template = if (useMinimalPrompt) MINIMAL_PROMPT_TEMPLATE else USER_PROMPT_TEMPLATE
+        return template.replace(USER_PROMPT_PLACEHOLDER, sanitizedAgentText)
     }
 
     fun sanitizeHtml(html: String): String {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -99,7 +99,18 @@
         android:layout_height="wrap_content"
         android:text="@string/generate_html"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/generateMinimalButton"
         app:layout_constraintStart_toStartOf="parent" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/generateMinimalButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:text="@string/generate_html_minimal"
+        app:layout_constraintBaseline_toBaselineOf="@id/generateButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/generateButton" />
 
     <ProgressBar
         android:id="@+id/progressBar"
@@ -109,7 +120,7 @@
         android:indeterminate="true"
         android:visibility="gone"
         app:layout_constraintBaseline_toBaselineOf="@id/generateButton"
-        app:layout_constraintStart_toEndOf="@id/generateButton"
+        app:layout_constraintStart_toEndOf="@id/generateMinimalButton"
         app:layout_constraintTop_toTopOf="@id/generateButton"
         app:layout_constraintVertical_bias="0.5" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="prompt_hint">Paste agent output to generate UI</string>
     <string name="load_model">Load Model</string>
     <string name="generate_html">Generate UI</string>
+    <string name="generate_html_minimal">Generate Lite UI</string>
     <string name="sample_prompt">Bill due for SmartGrid Energy on 18 May 2024.&#10;Outstanding ₹2,450.&#10;Show summary with due date, autopay toggle, and call support option.</string>
     <string name="select_model_file">Browse model file</string>
     <string name="preview_title">Generated UI</string>


### PR DESCRIPTION
## Summary
- add a second "Generate Lite UI" button alongside the existing generator
- support launching the preview with a minimal prompt template for faster inference

## Testing
- ./gradlew lint *(fails: SDK location not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d004ad7b8483268f85a1b5ad821b0c