### PR TITLE
Adjust prompts for lite UI generation

### DIFF
--- a/app/src/main/cpp/qwen_coder_bridge.cpp
+++ b/app/src/main/cpp/qwen_coder_bridge.cpp
@@ -60,9 +60,7 @@ FINAL CHECK
 
 
 static const char *kSystemInstruction =
-        "You are an expert front-end engineer. Generate polished HTML and CSS that can be "
-        "rendered directly inside a WebView. Avoid explanations. Include a single <style> "
-        "block at the top when CSS is required.";
+        "You are an expert front-end engineer producing accessible HTML/CSS.";
 
 static std::string apply_chat_template(const std::string &user_prompt) {
     if (user_prompt.find("<|im_start|>") != std::string::npos) {

--- a/app/src/main/java/com/samsung/genuiapp/UiGenerationUtils.kt
+++ b/app/src/main/java/com/samsung/genuiapp/UiGenerationUtils.kt
@@ -4,6 +4,7 @@ object UiGenerationUtils {
     const val MAX_TOKENS = 1024
 
     private const val USER_PROMPT_PLACEHOLDER = "{{agent_text}}"
+    private const val EMPTY_AGENT_FALLBACK = "No agent output provided."
 
     private val USER_PROMPT_TEMPLATE = """
         TASK: Turn the agent output into a production-quality, mobile-first GUI for a WebView.
@@ -22,16 +23,18 @@ object UiGenerationUtils {
         - Output only ONE ```html code block.
         - Use only inline CSS/SVG; no external assets.
         - Put data-action and, when helpful, data-payload JSON on all interactive elements.
-    """.trimIndent()
 
-    private val MINIMAL_PROMPT_TEMPLATE = """
-        You are an expert front-end engineer producing accessible HTML/CSS.
+        # agent_output
+        {{agent_text}}
     """.trimIndent()
 
     fun buildPrompt(agentText: String, useMinimalPrompt: Boolean = false): String {
-        val sanitizedAgentText = agentText.ifBlank { "No agent output provided." }
-        val template = if (useMinimalPrompt) MINIMAL_PROMPT_TEMPLATE else USER_PROMPT_TEMPLATE
-        return template.replace(USER_PROMPT_PLACEHOLDER, sanitizedAgentText)
+        val sanitizedAgentText = agentText.ifBlank { EMPTY_AGENT_FALLBACK }
+        return if (useMinimalPrompt) {
+            sanitizedAgentText
+        } else {
+            USER_PROMPT_TEMPLATE.replace(USER_PROMPT_PLACEHOLDER, sanitizedAgentText)
+        }
     }
 
     fun sanitizeHtml(html: String): String {


### PR DESCRIPTION
## Summary
- ensure the lite UI generation sends the raw agent text without additional templating
- embed the agent output into the standard UI generation prompt
- align the native system prompt with the new accessible front-end guidance

## Testing
- ./gradlew lint *(fails: SDK location not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0352adf888326b9afb8a5e931df0e