### PR TITLE
Simplify generate button layout

### DIFF
--- a/app/src/main/java/com/samsung/genuiapp/MainActivity.kt
+++ b/app/src/main/java/com/samsung/genuiapp/MainActivity.kt
@@ -52,12 +52,10 @@ class MainActivity : AppCompatActivity() {
         restoreLastModelPath()
         binding.promptInput.setText(getString(R.string.sample_prompt))
 
-        binding.generateButton.isEnabled = false
         binding.generateMinimalButton.isEnabled = false
 
         binding.modelPathLayout.setEndIconOnClickListener { openModelPicker() }
         binding.loadModelButton.setOnClickListener { loadModel() }
-        binding.generateButton.setOnClickListener { generateUi(useMinimalPrompt = false) }
         binding.generateMinimalButton.setOnClickListener { generateUi(useMinimalPrompt = true) }
     }
 
@@ -88,7 +86,6 @@ class MainActivity : AppCompatActivity() {
         binding.progressBar.isVisible = true
         updateStatus("Loading model...")
         binding.loadModelButton.isEnabled = false
-        binding.generateButton.isEnabled = false
         binding.generateMinimalButton.isEnabled = false
 
         val threads = maxOf(1, Runtime.getRuntime().availableProcessors() - 1)
@@ -110,7 +107,6 @@ class MainActivity : AppCompatActivity() {
 
             if (success) {
                 isModelReady = true
-                binding.generateButton.isEnabled = true
                 binding.generateMinimalButton.isEnabled = true
                 getPreferences(MODE_PRIVATE).edit()
                     .putString(KEY_MODEL_PATH, requestedPath)
@@ -150,7 +146,6 @@ class MainActivity : AppCompatActivity() {
     private fun resetLoadingUi() {
         binding.progressBar.isVisible = false
         binding.loadModelButton.isEnabled = true
-        binding.generateButton.isEnabled = isModelReady
         binding.generateMinimalButton.isEnabled = isModelReady
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -74,7 +74,7 @@
         android:layout_height="0dp"
         android:layout_marginTop="12dp"
         android:layout_marginBottom="16dp"
-        app:layout_constraintBottom_toTopOf="@id/generateButton"
+        app:layout_constraintBottom_toTopOf="@id/generateMinimalButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/statusText">
@@ -94,23 +94,13 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.button.MaterialButton
-        android:id="@+id/generateButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/generate_html"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/generateMinimalButton"
-        app:layout_constraintStart_toStartOf="parent" />
-
-    <com.google.android.material.button.MaterialButton
         android:id="@+id/generateMinimalButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
         android:text="@string/generate_html_minimal"
-        app:layout_constraintBaseline_toBaselineOf="@id/generateButton"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/generateButton" />
+        app:layout_constraintStart_toStartOf="parent" />
 
     <ProgressBar
         android:id="@+id/progressBar"
@@ -119,9 +109,9 @@
         android:layout_height="wrap_content"
         android:indeterminate="true"
         android:visibility="gone"
-        app:layout_constraintBaseline_toBaselineOf="@id/generateButton"
+        app:layout_constraintBaseline_toBaselineOf="@id/generateMinimalButton"
         app:layout_constraintStart_toEndOf="@id/generateMinimalButton"
-        app:layout_constraintTop_toTopOf="@id/generateButton"
+        app:layout_constraintTop_toTopOf="@id/generateMinimalButton"
         app:layout_constraintVertical_bias="0.5" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,8 +4,7 @@
     <string name="model_path_hint">Model file path (GGUF)</string>
     <string name="prompt_hint">Paste agent output to generate UI</string>
     <string name="load_model">Load Model</string>
-    <string name="generate_html">Generate UI</string>
-    <string name="generate_html_minimal">Generate Lite UI</string>
+    <string name="generate_html_minimal">Generate UI</string>
     <string name="sample_prompt">Bill due for SmartGrid Energy on 18 May 2024.&#10;Outstanding ₹2,450.&#10;Show summary with due date, autopay toggle, and call support option.</string>
     <string name="select_model_file">Browse model file</string>
     <string name="preview_title">Generated UI</string>


### PR DESCRIPTION
## Summary
- remove the duplicate generate button from the main screen and center the remaining control
- rename the lite generation label to "Generate UI" and keep logic focused on the single button

## Testing
- ./gradlew lint *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d060e755ec83268635754752761891